### PR TITLE
Fix GLFW lib name for linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Use GLFW or GLUT for creating windows and OpenGL rendering contexts.
 
 *   Though I have not tested on Linux yet, it should work with proper 'OpenGL.load_dll' settings like:
 	*   OpenGL.load_dll( 'libGL.so', '/usr/lib' )
-	*   GLFW.load_dll( 'libGLFW.so', '.' )
+	*   GLFW.load_dll( 'libglfw.so', '/usr/lib' )
 
 
 ## Note ##


### PR DESCRIPTION
Hi,
I have tested your simple.rb sample and it works with:

    OpenGL.load_dll( 'libGL.so', '/usr/lib')
    GLFW.load_dll( 'libglfw.so', '/usr/lib')

I use Archlinux x86_64 but the name of the lib GLFW seems to be the same under other distros (Debian, Fedora)
