### PR TITLE
clean load_lib and make sample working on linux

### DIFF
--- a/lib/glfw.rb
+++ b/lib/glfw.rb
@@ -341,11 +341,15 @@ module GLFW
       when :OPENGL_PLATFORM_MACOSX
         lib, path = 'libglfw.dylib', Dir.pwd
       else
-        lib, path = 'libglfw.so', Dir.pwd
+        lib = 'libglfw.so'
       end
     end
 
-    dlload (path + '/' + lib)
+    if path
+      dlload (path + '/' + lib)
+    else
+      dlload (lib)
+    end
     import_symbols() unless @@glfw_import_done
   end
 

--- a/lib/glfw30.rb
+++ b/lib/glfw30.rb
@@ -318,11 +318,15 @@ module GLFW
       when :OPENGL_PLATFORM_MACOSX
         lib, path = 'libglfw.dylib', Dir.pwd
       else
-        lib, path = 'libglfw.so', Dir.pwd
+        lib = 'libglfw.so'
       end
     end
-
-    dlload (path + '/' + lib)
+    
+    if path
+      dlload (path + '/' + lib)
+    else
+      dlload (lib)
+    end
     import_symbols() unless @@glfw_import_done
   end
 

--- a/sample/GLES/gles.rb
+++ b/sample/GLES/gles.rb
@@ -3,7 +3,12 @@ require 'opengl_es'
 require 'glfw'
 
 OpenGL.load_lib()
-GLFW.load_lib('glfw3.dll', '..')
+
+if OpenGL.get_platform == :OPENGL_PLATFORM_WINDOWS
+  GLFW.load_lib('glfw3.dll', '..')
+else
+  GLFW.load_lib()
+end
 
 include OpenGL
 include GLFW

--- a/sample/util/setup_dll.rb
+++ b/sample/util/setup_dll.rb
@@ -22,27 +22,6 @@ include GLFW
 include OpenGL
 include GLU
 
-def get_linux_libdir(libname)
-  # http://www.pilotlogic.com/sitejoom/index.php/wiki?id=398<F37>
-  # 32              64
-  # /usr/lib        /usr/lib64       redhat, mandriva
-  # /usr/lib32      /usr/lib64       arch, gento
-  # /usr/lib        /usr/lib64       slackware
-  # /usr/lib/i386.. /usr/lib/x86_64..  debian
-  libs = Dir.glob("/usr/lib*/#{libname}") # libs in /usr/lib or /usr/lib64 for most distribs
-  libs = Dir.glob("/usr/lib*/*/#{libname}") if libs.empty? # debian like
-  if libs.empty?
-    puts "no #{libname} found"
-    exit 1
-  end
-  # Get the same architecture that the runnning ruby
-  if 1.size == 8 # 64 bits
-    File.dirname(libs.grep(/64/).first)
-  else # 32 bits
-    File.dirname(libs.first)
-  end
-end
-
 case OpenGL.get_platform
 when :OPENGL_PLATFORM_WINDOWS
   OpenGL.load_lib('opengl32.dll', 'C:/Windows/System32')
@@ -53,9 +32,9 @@ when :OPENGL_PLATFORM_MACOSX
   GLU.load_lib('libGLU.dylib', '/System/Library/Frameworks/OpenGL.framework/Libraries')
   GLFW.load_lib('libglfw.dylib', '..')
 when :OPENGL_PLATFORM_LINUX
-  OpenGL.load_lib('libGL.so', get_linux_libdir('libGL.so'))
-  GLU.load_lib('libGLU.so', get_linux_libdir('libGLU.so'))
-  GLFW.load_lib('libglfw.so', get_linux_libdir('libglfw.so'))
+  OpenGL.load_lib()
+  GLU.load_lib()
+  GLFW.load_lib()
 else
   raise RuntimeError, "Unsupported platform."
 end


### PR DESCRIPTION
It looks like that if you only give the lib name to `Fiddle::dlload` or `Fiddle::dlopen`, Fiddle just find out the system library dir. That is why I have removed the get_linux_lib_dir function.
