### PR TITLE
Fix NoMethodError when calling wglGetProcAddress

### DIFF
--- a/lib/opengl_windows.rb
+++ b/lib/opengl_windows.rb
@@ -23,7 +23,7 @@ module OpenGL
   WGL_FUNCTIONS_ARGS_MAP[:wglGetProcAddress] = [Fiddle::TYPE_VOIDP]
   WGL_FUNCTIONS_RETVAL_MAP[:wglGetProcAddress] = Fiddle::TYPE_VOIDP
 
-  def wglGetProcAddress(_lpszProc_)
+  def self.wglGetProcAddress(_lpszProc_)
     f = OpenGL::get_wgl_command(:wglGetProcAddress)
     f.call(_lpszProc_)
   end


### PR DESCRIPTION
This stood out when calling glGenRenderbuffers() on Windows. Error was:

```
C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/opengl-bindings-1.6.5/lib/opengl_common.rb:45:in `rescue in bind_command': undefined method `wglGetProcAddress' for OpenGL:Module (NoMethodError)
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/opengl-bindings-1.6.5/lib/opengl_common.rb:38:in `bind_command'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/opengl-bindings-1.6.5/lib/opengl_common.rb:33:in `get_command'
        from C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/opengl-bindings-1.6.5/lib/opengl_command.rb:4298:in `glGenRenderbuffers'
```