### PR TITLE
Fix signature for glfwSetMonitorUserPointer

### DIFF
--- a/lib/glfw.rb
+++ b/lib/glfw.rb
@@ -529,7 +529,7 @@ module GLFW
     'void glfwGetMonitorPhysicalSize(void*, int*, int*)',
     'void glfwGetMonitorContentScale(void*, float*, float*)',      # Available since GLFW 3.3
     'const char* glfwGetMonitorName(void*)',
-    'const void glfwSetMonitorUserPointer(void*, void*)',          # Available since GLFW 3.3
+    'void glfwSetMonitorUserPointer(void*, void*)',          # Available since GLFW 3.3
     'const void* glfwGetMonitorUserPointer(void**)',               # Available since GLFW 3.3
     'void* glfwSetMonitorCallback(void*)',                         # Available since GLFW 3.0
     'const void* glfwGetVideoModes(void*, int*)',


### PR DESCRIPTION
Fiddle importer is raising an error that `const` is not a type when parsing the signature of `glfwSetMonitorUserPointer`. Removing the `const` fixes this. Based on GLFW's header files, this is correct since it does not have a `const` in the signature: https://github.com/glfw/glfw/blob/814b7929c5add4b0541ccad26fb81f28b71dc4d8/include/GLFW/glfw3.h#L2222