### PR TITLE
Fix libglfw.so name on linux

### DIFF
--- a/lib/glfw.rb
+++ b/lib/glfw.rb
@@ -469,7 +469,7 @@ module GLFW
                  when :OPENGL_PLATFORM_MACOSX
                    'libglfw.dylib'
                  else
-                   'libglfw.so' # not tested
+                   'libglfw.so.3'
                  end
     end
 

--- a/lib/opengl_common.rb
+++ b/lib/opengl_common.rb
@@ -13,7 +13,7 @@ module GL
       when :OPENGL_PLATFORM_MACOSX
         lib_path = '/System/Library/Frameworks/OpenGL.framework/Libraries/libGL.dylib'
       else
-        lib_path = 'libGL.so' # not tested
+        lib_path = 'libGL.so'
       end
     end
     @@gl_dll = Fiddle.dlopen(lib_path)


### PR DESCRIPTION
I just tested on linux and the lib version must be appended to be loaded correctly, libglfw.so.3 is a symlink of the latest version available on the system:
```
$ ls -la /usr/lib/x86_64-linux-gnu/libglfw*
lrwxrwxrwx 1 root root     14 janv. 30 04:54 /usr/lib/x86_64-linux-gnu/libglfw.so.3 -> libglfw.so.3.3
-rw-r--r-- 1 root root 282616 janv. 30 04:54 /usr/lib/x86_64-linux-gnu/libglfw.so.3.3
```

You can see here that with the right name, the lib is loaded:
```
irb(main):005:0> Fiddle.dlopen("libglfw.so")
/home/sebastien/.rbenv/versions/3.1.2/lib/ruby/3.1.0/fiddle.rb:61:in `initialize': libglfw.so: cannot open shared object file: No such file or directory (Fiddle::DLError)
        from /home/sebastien/.rbenv/versions/3.1.2/lib/ruby/3.1.0/fiddle.rb:61:in `new'         
        from /home/sebastien/.rbenv/versions/3.1.2/lib/ruby/3.1.0/fiddle.rb:61:in `dlopen'
        from (irb):5:in `<main>'                        
        from /home/sebastien/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/irb-1.4.1/exe/irb:11:in `<top (required)>'
        from /home/sebastien/.rbenv/versions/3.1.2/bin/irb:25:in `load'
        from /home/sebastien/.rbenv/versions/3.1.2/bin/irb:25:in `<main>'

irb(main):006:0> Fiddle.dlopen("libglfw.so.3")
=> #<Fiddle::Handle:0x00007f057c99e840>
```