### PR TITLE
Explicitly declare fiddle as a dependency

### DIFF
--- a/opengl-bindings.gemspec
+++ b/opengl-bindings.gemspec
@@ -20,4 +20,6 @@ Ruby bindings for OpenGL - 4.6, OpenGL ES - 3.2 and all extensions using Fiddle 
   gem.files = Dir.glob("lib/*.rb") +
               ["README.md", "LICENSE.txt", "ChangeLog"] +
               ["sample/simple.rb", "sample/report_env.rb", "sample/glfw_get.sh", "sample/glfw_get.bat", "sample/README.md"]
+
+  gem.add_runtime_dependency "fiddle", "~> 1.0"
 end


### PR DESCRIPTION
It's going to be removed from default gems in Ruby 3.5.0, and currently shows a warning as noted in #37

Resolves #37